### PR TITLE
Fix typo regarding SNS

### DIFF
--- a/src/pages/serverless-elements/index.mdx
+++ b/src/pages/serverless-elements/index.mdx
@@ -174,7 +174,7 @@ Extract messages into an array of strings and process with a loop. Throw an err
 
 ### SNS
 
-A useful alternative to SQS is the Simple Notification Service – SQS. Similar behavior, except you can't store messages on the queue.
+A useful alternative to SQS is the Simple Notification Service – SNS. Similar behavior, except you can't store messages on the queue.
 
 With SNS each message sends *once*. If you don't catch it, it's gone.
 


### PR DESCRIPTION
line 177 read, `A useful alternative to SQS is the Simple Notification Service – SQS.`. The second `SQS` should be `SNS`, since that is the service the section is describing.