### PR TITLE
Fixed deadlink inside Using GraphQL Api

### DIFF
--- a/src/pages/serverless-graphql/index.mdx
+++ b/src/pages/serverless-graphql/index.mdx
@@ -321,7 +321,7 @@ Should you rip out your REST API and rewrite for GraphQL? Please don't.
 
 GraphQL doesn't care where data comes from. Relational database, NoSQL database, files, a REST API, another GraphQL API ... All you need is a function that reads data in response to a query.
 
-You can [start using GraphQL without changing your existing server](https://swizec.com/blog/how-you-can-start-using-graphql-today-without-changing-the-backend/swizec/9350) with a GraphQL middle layer. Create a GraphQL server on top of your REST API.
+You can [start using GraphQL without changing your existing server](https://swizec.com/blog/how-you-can-start-using-graphql-today-without-changing-the-backend/) with a GraphQL middle layer. Create a GraphQL server on top of your REST API.
 
 ![](giphy:wow)
 


### PR DESCRIPTION
Link https://swizec.com/blog/how-you-can-start-using-graphql-today-without-changing-the-backend/swizec/9350 is a dead link and I updated it to the correct version to https://swizec.com/blog/how-you-can-start-using-graphql-today-without-changing-the-backend/

Seems "/swizec/9350" was the culprit