### PR TITLE
Allow rest-sample to run without passing CLI flags to serverless deploy

### DIFF
--- a/examples/serverless-rest-example/serverless.yml
+++ b/examples/serverless-rest-example/serverless.yml
@@ -3,6 +3,7 @@ service: serverless-rest-example
 provider:
   name: aws
   runtime: nodejs12.x
+  region: us-east-1
   stage: dev
   environment:
     ITEM_TABLE: ${self:service}-items-${self:provider.stage}


### PR DESCRIPTION
`serverless deploy` with the rest-example returns this error:
```
 Serverless Error ----------------------------------------

  Cannot resolve serverless.yml: Variables resolution errored with:
    - Cannot resolve variable at "provider.iamRoleStatements.0.Resource": Value not found at "self" source
```

It may not be immediately obvious this is because the region needs to be set either in the yaml or in the cli using `serverless deploy --region us-east-1`.